### PR TITLE
test: 替换成vitest文档能查到的Api

### DIFF
--- a/packages/core/__tests__/app.spec.ts
+++ b/packages/core/__tests__/app.spec.ts
@@ -62,8 +62,8 @@ describe('app', () => {
     const setup = vi.fn()
     createApp({ onLaunch, setup })
     app.onLaunch(arg)
-    expect(onLaunch).toBeCalledWith(arg)
-    expect(setup).toBeCalledWith(arg)
+    expect(onLaunch).toHaveBeenCalledWith(arg)
+    expect(setup).toHaveBeenCalledWith(arg)
   })
 
   it('onShow', () => {
@@ -80,9 +80,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onShow(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onHide', () => {
@@ -98,9 +98,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onHide()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onError', () => {
@@ -117,9 +117,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onError(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onPageNotFound', () => {
@@ -136,9 +136,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onPageNotFound(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onUnhandledRejection', () => {
@@ -155,9 +155,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onUnhandledRejection(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onThemeChange', () => {
@@ -174,9 +174,9 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onThemeChange(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('inject lifecycle outside setup', () => {
@@ -196,7 +196,7 @@ describe('app', () => {
     expect(app.num).toBe(0)
 
     app.onHide()
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('only injected lifecycle', () => {
@@ -206,7 +206,7 @@ describe('app', () => {
     })
     app.onLaunch()
     app.onHide()
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('no setup', () => {

--- a/packages/core/__tests__/component.spec.ts
+++ b/packages/core/__tests__/component.spec.ts
@@ -404,7 +404,7 @@ describe('component', () => {
     component.data = { count: 0 }
     component.lifetimes.attached.call(component)
     component.observers.count.call(component, component.data.count)
-    expect(fn).toBeCalledWith(0)
+    expect(fn).toHaveBeenCalledWith(0)
   })
 
   it('context', () => {
@@ -424,7 +424,7 @@ describe('component', () => {
       setup() {},
     })
     component.lifetimes.attached.call(component)
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('legacy attached', () => {
@@ -434,7 +434,7 @@ describe('component', () => {
       setup() {},
     })
     component.lifetimes.attached.call(component)
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('ready', () => {
@@ -453,9 +453,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.ready.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('legacy ready', () => {
@@ -466,7 +466,7 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.ready.call(component)
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('moved', () => {
@@ -482,9 +482,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.moved.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('legacy moved', () => {
@@ -495,7 +495,7 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.moved.call(component)
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('detached', () => {
@@ -511,9 +511,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.detached.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('legacy detached', () => {
@@ -524,7 +524,7 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.detached.call(component)
-    expect(fn).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 
   it('error', () => {
@@ -541,9 +541,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.error.call(component, error)
-    expect(fn).toBeCalledWith(error)
-    expect(injectedFn1).toBeCalledWith(error)
-    expect(injectedFn2).toBeCalledWith(error)
+    expect(fn).toHaveBeenCalledWith(error)
+    expect(injectedFn1).toHaveBeenCalledWith(error)
+    expect(injectedFn2).toHaveBeenCalledWith(error)
   })
 
   it('legacy error', () => {
@@ -555,7 +555,7 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.lifetimes.error.call(component, error)
-    expect(fn).toBeCalledWith(error)
+    expect(fn).toHaveBeenCalledWith(error)
   })
 
   it('onLoad', () => {
@@ -572,9 +572,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.methods.onLoad.call(component, arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onPullDownRefresh', () => {
@@ -590,9 +590,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.methods.onPullDownRefresh.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onReachBottom', () => {
@@ -608,9 +608,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.methods.onReachBottom.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onTabItemTap', () => {
@@ -627,9 +627,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.methods.onTabItemTap.call(component, arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onPageScroll', () => {
@@ -657,9 +657,9 @@ describe('component', () => {
     component.__listenPageScroll__ = component.methods.__listenPageScroll__
     component.lifetimes.attached.call(component)
     component.methods.onPageScroll.call(component, arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
 
     const injectedFn = vi.fn()
     defineComponent(
@@ -671,7 +671,7 @@ describe('component', () => {
     component.__listenPageScroll__ = component.methods.__listenPageScroll__
     component.lifetimes.attached.call(component)
     component.methods.onPageScroll.call(component, arg)
-    expect(injectedFn).toBeCalledWith(arg)
+    expect(injectedFn).toHaveBeenCalledWith(arg)
   })
 
   it('onShareAppMessage', () => {
@@ -732,7 +732,7 @@ describe('component', () => {
       component,
       arg,
     )
-    expect(fn).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
     expect(shareContent).toEqual({ title: 'test' })
 
     defineComponent(() => {}, { canShareToOthers: true })
@@ -796,7 +796,7 @@ describe('component', () => {
       component.methods.__isInjectedShareToTimelineHook__
     component.lifetimes.attached.call(component)
     const shareContent = component.methods.onShareTimeline.call(component)
-    expect(fn).toBeCalledWith()
+    expect(fn).toHaveBeenCalledWith()
     expect(shareContent).toEqual({ title: 'test' })
 
     defineComponent(() => {}, { canShareToTimeline: true })
@@ -846,7 +846,7 @@ describe('component', () => {
       component,
       arg,
     )
-    expect(fn).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
     expect(favoritesContent).toEqual({ title: 'test' })
 
     defineComponent(() => {})
@@ -909,9 +909,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.pageLifetimes.show.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onHide', () => {
@@ -927,9 +927,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.pageLifetimes.hide.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onResize', () => {
@@ -946,9 +946,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.pageLifetimes.resize.call(component, arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onRouteDone', () => {
@@ -964,9 +964,9 @@ describe('component', () => {
     })
     component.lifetimes.attached.call(component)
     component.pageLifetimes.routeDone.call(component)
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('inject component lifecycle outside setup', () => {

--- a/packages/core/__tests__/page.spec.ts
+++ b/packages/core/__tests__/page.spec.ts
@@ -334,8 +334,8 @@ describe('page', () => {
     })
     definePage({ onLoad, setup })
     page.onLoad(arg)
-    expect(onLoad).toBeCalledWith(arg)
-    expect(setup).toBeCalledTimes(1)
+    expect(onLoad).toHaveBeenCalledWith(arg)
+    expect(setup).toHaveBeenCalledTimes(1)
   })
 
   it('onReady', () => {
@@ -354,9 +354,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onReady()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onShow', () => {
@@ -372,9 +372,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onShow()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onHide', () => {
@@ -390,9 +390,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onHide()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onUnload', async () => {
@@ -408,9 +408,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onUnload()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onRouteDone', () => {
@@ -426,9 +426,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onRouteDone()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onPullDownRefresh', () => {
@@ -444,9 +444,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onPullDownRefresh()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onReachBottom', () => {
@@ -462,9 +462,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onReachBottom()
-    expect(fn).toBeCalledTimes(1)
-    expect(injectedFn1).toBeCalledTimes(1)
-    expect(injectedFn2).toBeCalledTimes(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(injectedFn1).toHaveBeenCalledTimes(1)
+    expect(injectedFn2).toHaveBeenCalledTimes(1)
   })
 
   it('onResize', () => {
@@ -481,9 +481,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onResize(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onTabItemTap', () => {
@@ -500,9 +500,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onTabItemTap(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
   })
 
   it('onPageScroll', () => {
@@ -528,9 +528,9 @@ describe('page', () => {
     })
     page.onLoad()
     page.onPageScroll(arg)
-    expect(fn).toBeCalledWith(arg)
-    expect(injectedFn1).toBeCalledWith(arg)
-    expect(injectedFn2).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
+    expect(injectedFn1).toHaveBeenCalledWith(arg)
+    expect(injectedFn2).toHaveBeenCalledWith(arg)
 
     const injectedFn = vi.fn()
     definePage(
@@ -541,7 +541,7 @@ describe('page', () => {
     )
     page.onLoad()
     page.onPageScroll(arg)
-    expect(injectedFn).toBeCalledWith(arg)
+    expect(injectedFn).toHaveBeenCalledWith(arg)
   })
 
   it('onShareAppMessage', () => {
@@ -585,7 +585,7 @@ describe('page', () => {
     )
     page.onLoad()
     const shareContent = page.onShareAppMessage(arg)
-    expect(fn).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
     expect(shareContent).toEqual({ title: 'test' })
 
     definePage(() => {}, { canShareToOthers: true })
@@ -635,7 +635,7 @@ describe('page', () => {
     )
     page.onLoad()
     const shareContent = page.onShareTimeline()
-    expect(fn).toBeCalledWith()
+    expect(fn).toHaveBeenCalledWith()
     expect(shareContent).toEqual({ title: 'test' })
 
     definePage(() => {}, { canShareToTimeline: true })
@@ -674,7 +674,7 @@ describe('page', () => {
     })
     page.onLoad()
     const favoritesContent = page.onAddToFavorites(arg)
-    expect(fn).toBeCalledWith(arg)
+    expect(fn).toHaveBeenCalledWith(arg)
     expect(favoritesContent).toEqual({ title: 'test' })
 
     definePage(() => {})

--- a/packages/core/__tests__/watch.spec.ts
+++ b/packages/core/__tests__/watch.spec.ts
@@ -74,8 +74,8 @@ describe('watch', () => {
     watch(array, spy)
     array.push(1)
     await nextTick()
-    expect(spy).toBeCalledTimes(1)
-    expect(spy).toBeCalledWith([1], expect.anything(), expect.anything())
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith([1], expect.anything(), expect.anything())
   })
 
   it('should not call functions inside a reactive source array', () => {
@@ -83,8 +83,8 @@ describe('watch', () => {
     const array = reactive([spy1])
     const spy2 = vi.fn()
     watch(array, spy2, { immediate: true })
-    expect(spy1).toBeCalledTimes(0)
-    expect(spy2).toBeCalledWith([spy1], undefined, expect.anything())
+    expect(spy1).toHaveBeenCalledTimes(0)
+    expect(spy2).toHaveBeenCalledWith([spy1], undefined, expect.anything())
   })
 
   it('should not unwrap refs in a reactive source array', async () => {
@@ -92,14 +92,14 @@ describe('watch', () => {
     const array = reactive([val])
     const spy = vi.fn()
     watch(array, spy, { immediate: true })
-    expect(spy).toBeCalledTimes(1)
-    expect(spy).toBeCalledWith([val], undefined, expect.anything())
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith([val], undefined, expect.anything())
 
     // Deep by default
     val.value.foo++
     await nextTick()
-    expect(spy).toBeCalledTimes(2)
-    expect(spy).toBeCalledWith([val], [val], expect.anything())
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy).toHaveBeenCalledWith([val], [val], expect.anything())
   })
 
   it('should not fire if watched getter result did not change', async () => {
@@ -109,12 +109,12 @@ describe('watch', () => {
 
     n.value++
     await nextTick()
-    expect(spy).toBeCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(1)
 
     n.value += 2
     await nextTick()
     // Should not be called again because getter result did not change
-    expect(spy).toBeCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('watching single source: computed ref', async () => {
@@ -197,17 +197,17 @@ describe('watch', () => {
     const array: any[] = reactive([val])
     const spy = vi.fn()
     watch(array, spy, { immediate: true, deep: false })
-    expect(spy).toBeCalledTimes(1)
-    expect(spy).toBeCalledWith([val], undefined, expect.anything())
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith([val], undefined, expect.anything())
 
     val.value++
     await nextTick()
-    expect(spy).toBeCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(1)
 
     array[1] = 2
     await nextTick()
-    expect(spy).toBeCalledTimes(2)
-    expect(spy).toBeCalledWith([val, 2], [val, 2], expect.anything())
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy).toHaveBeenCalledWith([val, 2], [val, 2], expect.anything())
   })
 
   // #9916
@@ -227,12 +227,12 @@ describe('watch', () => {
     collection[0].prop1.value = 'foo'
     await nextTick()
     // Should not trigger
-    expect(cb).toBeCalledTimes(0)
+    expect(cb).toHaveBeenCalledTimes(0)
 
     collection.push(new Foo())
     await nextTick()
     // Should trigger on array self mutation
-    expect(cb).toBeCalledTimes(1)
+    expect(cb).toHaveBeenCalledTimes(1)
   })
 
   it('should still respect deep: true on shallowReactive source', async () => {
@@ -772,7 +772,7 @@ describe('watch', () => {
     })
     foo.value = [...foo.value]
     await nextTick()
-    expect(spy).toBeCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   test('watching multiple sources: computed', async () => {
@@ -934,7 +934,7 @@ describe('watch', () => {
 
     source.count = 1
     await nextTick()
-    expect(spy).toBeCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it('warn and not respect once option when using effect', async () => {
@@ -1000,12 +1000,12 @@ describe('watch', () => {
     collection[0].prop1.value = 'foo'
     await nextTick()
     // Should not trigger
-    expect(cb).toBeCalledTimes(0)
+    expect(cb).toHaveBeenCalledTimes(0)
 
     collection.push(new Foo())
     await nextTick()
     // Should trigger on array self mutation
-    expect(cb).toBeCalledTimes(1)
+    expect(cb).toHaveBeenCalledTimes(1)
   })
 
   it('warn if deep option is number', async () => {


### PR DESCRIPTION
看测试用例发现，api在vitest文档中没找到，改成vitest文档有的，方便查找（后面在jest文档中找到了，是个别名api）