### PR TITLE
fix: Update Bindings type from 'any' to 'unknown' to prevent async se…

### DIFF
--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -1,6 +1,6 @@
 import type { EffectScope } from '@vue/reactivity'
 
-export type Bindings = Record<string, any> | void
+export type Bindings = Record<string, unknown> | void
 
 export type AppInstance = Record<string, any>
 


### PR DESCRIPTION
…tup functions

## 背景

Vue Mini 的作者你好，首先我挺喜欢这个框架的，最近正在使用该框架开发一个小程序，但我遇到了一个问题，也就是该 Issue #19 中提到的 setup 不能使用异步函数（但我之前并没有注意到这个Issue，文档中似乎也没有提到）。

所以之前很习惯性的类似 `onMounted(async () => {})` 一样使用 `definePage(async () => {})` ，编码阶段并没有任何的报错提示，只是在运行阶段，出现了 js 与 wxml 之间似乎没有绑定成功的 BUG ，并且没有任何的报错提示，只有在点击时出现 `XX is undefined` 等提示。

我最开始怀疑我的业务代码，直到我删除了几乎所有的业务代码，之后又怀疑是不是最近微信小程序工具更新导致的，于是回退了版本到稳定版本，最后试着删除了 async 标识，终于解决了！

## 修改

作为一款开发者使用的框架，良好的错误提示是必要的，我尝试拉取代码来修改，比如增加
```ts
if(__DEV__ && setup 是否是async函数) 打印警告;
```
但在 AI 的提醒下，我发现类型文件就可以胜任该工作，只是现在的源码中的返回掺杂了 `any` 导致类型检查失败，所以这里我理解可以使用 unknown 来替代，以提醒开发者这里不能是一个 Promise 返回的函数。

使用unknown（async会报错）:

![image](https://github.com/user-attachments/assets/76a168de-0927-4734-afc8-b57e85d12bcf)

![image](https://github.com/user-attachments/assets/dbf5e793-f3a6-44ae-9d68-9bd895c79ace)

使用any（async没有任何提示）:

![image](https://github.com/user-attachments/assets/c8ce7f5a-d39b-4a27-afc2-b605f7b95414)

## 其他

- 我不清楚这里之前加 `any` 是为了兼容什么，但我换成了 `unknown` 之后运行 `pnpm run type` 没有报错；
- `export type AppInstance = Record<string, any>`这里我不太确定是否需要做类似的修改。